### PR TITLE
Adding a safety switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 
 # puppet-lustre
 Puppet module to install and configure Lustre
+
+Puppet is only allowed to format devices if the file `/tmp/puppet_can_erase` exist

--- a/manifests/mds.pp
+++ b/manifests/mds.pp
@@ -33,7 +33,8 @@ class lustre::mds(
 -O compression=${compression} \
 ${lustre::server::fsname}-mdt${index} \
 ${format_str}",
-      unless  => "/usr/sbin/blkid ${drives_str} | /usr/bin/grep zfs",
+      unless  => ['/usr/bin/test ! -f /tmp/puppet_can_erase',
+                  "/usr/sbin/blkid ${drives_str} | /usr/bin/grep zfs"],
       require => Class['luks'],
     }
     ~> exec { "Formating the MDT${index} with Lustre":
@@ -46,6 +47,7 @@ ${service_nodes_str} \
 ${mgs_nodes_str} \
 ${lustre::server::fsname}-mdt${index}/mdt${index}",
       refreshonly => true,
+      onlyif      => '/usr/bin/test -f /tmp/puppet_can_erase',
     }
     -> file { "/mnt/mdt${index}":
       ensure => 'directory',

--- a/manifests/mgs.pp
+++ b/manifests/mgs.pp
@@ -19,7 +19,8 @@ class lustre::mgs(
 -O compression=${compression} \
 ${lustre::server::fsname}-mgt \
 ${lustre::mgs::raid_level} ${drives_str}",
-    unless  => "/usr/sbin/blkid ${drives_str} | /usr/bin/grep zfs",
+    unless  => ['/usr/bin/test ! -f /tmp/puppet_can_erase',
+                "/usr/sbin/blkid ${drives_str} | /usr/bin/grep zfs"],
     require => Class['luks'],
   }
   ~> exec { 'Formating the MGT with Lustre':
@@ -29,6 +30,7 @@ ${lustre::mgs::raid_level} ${drives_str}",
 --mgs ${lustre::server::fsname}-mgt/mgt \
 ${service_nodes_str}",
     refreshonly => true,
+    onlyif      => '/usr/bin/test -f /tmp/puppet_can_erase',
   }
   -> file { '/mnt/mgt': ensure => 'directory' }
   -> cs_primitive { 'ZFS_MGT':

--- a/manifests/oss.pp
+++ b/manifests/oss.pp
@@ -36,7 +36,8 @@ class lustre::oss(
 -O compression=${compression} \
 ${lustre::server::fsname}-ost${index} \
 ${format_str}",
-      unless  => "/usr/sbin/blkid ${drives_str} | /usr/bin/grep zfs",
+      unless  => ['/usr/bin/test ! -f /tmp/puppet_can_erase',
+                  "/usr/sbin/blkid ${drives_str} | /usr/bin/grep zfs"],
       require => Class['luks'],
     }
     ~> exec { "Formating the OST${index} with Lustre":
@@ -49,6 +50,7 @@ ${service_nodes_str} \
 ${mgs_nodes_str} \
 ${lustre::server::fsname}-ost${index}/ost${index}",
       refreshonly => true,
+      onlyif      => '/usr/bin/test -f /tmp/puppet_can_erase',
     }
     -> file { "/mnt/ost${index}": ensure => 'directory' }
     -> cs_primitive { "ZFS_OST${index}":

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -16,6 +16,11 @@ class lustre::server(
     'lustre-resource-agents',
     'fence-agents-all',
   ]:}
+
+  exec { '/usr/bin/echo Warning, puppet is allowed to format drives':
+    unless => '/usr/bin/test ! -f /tmp/puppet_can_erase',
+  }
+
   file { '/etc/modprobe.d/spl.conf':
     content => "options spl spl_hostid=${spl_hostid}
 ",


### PR DESCRIPTION
Puppet will only format devices if the file `/tmp/puppet_can_erase` exist